### PR TITLE
WIP: Adding ESLint and Prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cypress/screenshots
 # when working with contributors
 package-lock.json
 yarn.lock
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "contributors:add": "all-contributors add",
     "build": "yarn install; kcd-scripts build --bundle --p-react",
+    "lint": "kcd-scripts lint",
     "storybook": "start-storybook -p 9001 -c stories",
     "build-storybook": "build-storybook -c stories -o storybook-static",
     "storybook:serve": "serve ./storybook-static -p 9001",
@@ -39,6 +40,15 @@
     "serve": "^6.5.4"
   },
   "dependencies": {},
+  "eslintConfig": {
+    "extends": "./node_modules/kcd-scripts/eslint.js"
+  },
+  "eslintIgnore": [
+    "node_modules",
+    "cypress",
+    "stories",
+    "storybook-static"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/deseretdigital/dayzed.git"


### PR DESCRIPTION
Hi :wave: 

As the title says, this PR is a WIP because I believe that it's important to discuss some ESLint rules and Prettier options to adopt or override.

**ESLint**

To get us started, I ran the `lint` script and got the following errors:

`prefer-const`: We have a lot of variables that are declared with `let`, but never are reassigned, so we should use `const`. I'd vote to keep this rule.

`react/no-unused-prop-types`: Some props are described in the `Dayzed.propTypes` declaration, but are never used because they're spread [here](https://github.com/deseretdigital/dayzed/blob/master/src/dayzed.js#L22). I'd vote to explicity destructure these props and pass them to `getCalendars` to get rid of the error.

`no-negated-condition`: I'd vote to disable this rule, because [this](https://github.com/deseretdigital/dayzed/blob/master/src/utils.js#L41) and [this](https://github.com/deseretdigital/dayzed/blob/master/src/utils.js#L282) are not a big deal.

`valid-jsdoc`: This rules points to lines like [this](https://github.com/deseretdigital/dayzed/blob/master/src/utils.js#L52), but I don't know if they should be removed.

`complexity`: `getCalendars` and `getMonths` are big functions considered "too complex". I'd vote to keep this rule and break this two into small functions.

`max-statements`: `getMonths` has too many statements. It's related with the `complexity` rule and will disappear if we refactor the functions.

**Prettier**

This is the configuration on `kcd-scripts`:

```
{
  printWidth: 80,
  tabWidth: 2,
  useTabs: false,
  semi: false,
  singleQuote: true,
  trailingComma: 'all',
  bracketSpacing: false,
  jsxBracketSameLine: false,
}
```

I'd suggest to replace the following:

```
  semi: true,
  bracketSpacing: true,
  jsxBracketSameLine: true,
```

What do you think?