### PR TITLE
feat: pass event as second argument to onDateSelected prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ function Calendar({ calendars, getBackProps, getForwardProps, getDateProps }) {
             ))}
             {calendar.weeks.map((week, weekIndex) =>
               week.map((dateObj, index) => {
-                let key = `${calendar.month}${
-                  calendar.year
-                }${weekIndex}${index}`;
+                let key = `${calendar.month}${calendar.year}${weekIndex}${index}`;
                 if (!dateObj) {
                   return (
                     <div
@@ -276,11 +274,12 @@ An array of `Date`s or a single `Date` that has been selected.
 
 ### onDateSelected
 
-> `function(selectedDate: date)` | _required_
+> `function(selectedDate: Date, event: Event)` | _required_
 
 Called when the user selects a date.
 
 - `selectedDate`: The date that was just selected.
+- `event`: The event fired when the date was selected.
 
 ### render
 

--- a/src/dayzed.js
+++ b/src/dayzed.js
@@ -25,8 +25,8 @@ function getDateProps(
   { onClick, dateObj = requiredProp('getDateProps', 'dateObj'), ...rest } = {}
 ) {
   return {
-    onClick: composeEventHandlers(onClick, () => {
-      onDateSelected(dateObj);
+    onClick: composeEventHandlers(onClick, event => {
+      onDateSelected(dateObj, event);
     }),
     disabled: !dateObj.selectable,
     'aria-label': dateObj.date.toDateString(),


### PR DESCRIPTION
What kind of change does this PR introduce?**
Feature. Closes #34.

**What is the current behavior?**
We are not passing the event to the `onDateSelected` prop.

**What is the new behavior?**
The event is passed as the second argument.

**Notes:**
- Documentation on README was updated too;
- I wasn't able to run the project locally because I kept getting the error `NodePath has been removed so is read-only` so I couldn't check the feature - (any tips on solving this?).