### PR TITLE
Add event parameter to onDateSelected signature

### DIFF
--- a/typings/dayzed-tests.tsx
+++ b/typings/dayzed-tests.tsx
@@ -13,7 +13,7 @@ class App extends React.Component<{}, State> {
     monthOffset: 0
   };
 
-  handleSetDate = (dateObj: DateObj) => {
+  handleSetDate = (dateObj: DateObj, _: React.SyntheticEvent) => {
     this.setState({ selectedDate: dateObj.date });
   };
 
@@ -24,10 +24,22 @@ class App extends React.Component<{}, State> {
         offset={this.state.monthOffset}
         onDateSelected={this.handleSetDate}
       >
-        {({ calendars, getDateProps, getBackProps, getForwardProps }) =>
-          (<>
-            <button {...getBackProps({ calendars, offset: 6, style: { backgroundColor: "blue" } })}></button>
-            <button {...getForwardProps({ calendars, offset: 6, style: { backgroundColor: "blue" } })}></button>
+        {({ calendars, getDateProps, getBackProps, getForwardProps }) => (
+          <>
+            <button
+              {...getBackProps({
+                calendars,
+                offset: 6,
+                style: { backgroundColor: 'blue' }
+              })}
+            ></button>
+            <button
+              {...getForwardProps({
+                calendars,
+                offset: 6,
+                style: { backgroundColor: 'blue' }
+              })}
+            ></button>
             {calendars.map(cal => (
               <div>
                 Calendar:
@@ -37,7 +49,12 @@ class App extends React.Component<{}, State> {
                     {week.map(
                       day =>
                         day && (
-                          <span {...getDateProps({ dateObj: day, style: { backgroundColor: "blue" } })}>
+                          <span
+                            {...getDateProps({
+                              dateObj: day,
+                              style: { backgroundColor: 'blue' }
+                            })}
+                          >
                             Day({day.date.getDate()}):
                           </span>
                         )
@@ -46,7 +63,8 @@ class App extends React.Component<{}, State> {
                 ))}
               </div>
             ))}
-          </>)}
+          </>
+        )}
       </Dayzed>
     );
   }
@@ -56,12 +74,24 @@ const HookApp = () => {
   const selectedDate = new Date();
   const { calendars, getDateProps, getBackProps, getForwardProps } = useDayzed({
     date: selectedDate,
-    onDateSelected: () => { }
+    onDateSelected: () => {}
   });
   return (
     <>
-      <button {...getBackProps({ calendars, offset: 6, style: { backgroundColor: "blue" } })}></button>
-      <button {...getForwardProps({ calendars, offset: 6, style: { backgroundColor: "blue" } })}></button>
+      <button
+        {...getBackProps({
+          calendars,
+          offset: 6,
+          style: { backgroundColor: 'blue' }
+        })}
+      ></button>
+      <button
+        {...getForwardProps({
+          calendars,
+          offset: 6,
+          style: { backgroundColor: 'blue' }
+        })}
+      ></button>
       {calendars.map(calendar => (
         <div>
           {calendar.weeks.map((week, windex) =>
@@ -75,7 +105,7 @@ const HookApp = () => {
                   key={key}
                   {...getDateProps({
                     dateObj,
-                    style: { backgroundColor: "blue" }
+                    style: { backgroundColor: 'blue' }
                   })}
                 >
                   {date.getDate()}

--- a/typings/dayzed.d.ts
+++ b/typings/dayzed.d.ts
@@ -17,7 +17,8 @@ export interface Calendar {
   year: number;
 }
 
-export interface GetBackForwardPropsOptions extends HTMLProps<HTMLButtonElement> {
+export interface GetBackForwardPropsOptions
+  extends HTMLProps<HTMLButtonElement> {
   calendars: Calendar[];
   offset?: number;
 }
@@ -47,7 +48,7 @@ export interface Props {
   render?: RenderFn;
   offset?: number;
   onOffsetChanged?(offset: number): void;
-  onDateSelected(selectedDate: DateObj): void;
+  onDateSelected(selectedDate: DateObj, event: React.SyntheticEvent): void;
 }
 
 export function useDayzed(


### PR DESCRIPTION
The typings for on `onDateSelected` are missing the second parameter, the `event`. [Source code here](https://github.com/deseretdigital/dayzed/blob/793ed0fcb43a7f47c0d78ca8024b018422549929/src/dayzed.js#L29).

PS: The format changes were done by the Git hook `pre-commit`.