### PR TITLE
chore: upgrade date-fns to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "date-fns": "^2.0.0"
+    "date-fns": "^3.6.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
-import addDays from 'date-fns/addDays';
-import isBefore from 'date-fns/isBefore';
-import isToday from 'date-fns/isToday';
-import startOfDay from 'date-fns/startOfDay';
-import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths';
+import { addDays } from 'date-fns/addDays';
+import { isBefore } from 'date-fns/isBefore';
+import { isToday } from 'date-fns/isToday';
+import { startOfDay } from 'date-fns/startOfDay';
+import { differenceInCalendarMonths } from 'date-fns/differenceInCalendarMonths';
 
 /**
  * This is intended to be used to compose event handlers
@@ -15,7 +15,9 @@ import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths';
 export function composeEventHandlers(...fns) {
   return (event, ...args) =>
     fns.some(fn => {
-      fn && fn(event, ...args);
+      if (fn) {
+        fn(event, ...args);
+      }
       return event.defaultPrevented;
     });
 }


### PR DESCRIPTION
Fixes #58 

- full TypeScript
- dropping IE support
- removed default exports

https://blog.date-fns.org/v3-is-out/

---

- [ ] Bump version